### PR TITLE
meshtastic: set SO_REUSEADDR on UDP socket to fix multicast delivery

### DIFF
--- a/meshtastic.uc
+++ b/meshtastic.uc
@@ -204,6 +204,7 @@ export function setup(config)
     }
     const address = config.meshtastic.address;
     s = socket.create(socket.AF_INET, socket.SOCK_DGRAM, 0);
+    s.setopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1);
     s.bind({
         port: PORT
     });


### PR DESCRIPTION
Localhost multicast sockets require SO_REUSEADDR so that multiple processes can bind to the same (address, port) pair and both receive multicast traffic. Without it, the kernel does not deliver multicast packets to all bound sockets. 

Needed to work on a service that can run on AREDN nodes bridging any USB-connected serial meshtastic device  to Raven (or any meshtastic over LAN clients) over localhost. Still testing <https://github.com/USA-RedDragon/meshtastic-serial-udp>