### PR TITLE
Fix null deref in decodePacket when no preset Meshtastic channel is configured

### DIFF
--- a/channel.uc
+++ b/channel.uc
@@ -156,7 +156,7 @@ function setLocalChannel(config)
 export function getChannelsByMeshtasticHash(hash)
 {
     if (!hash) {
-        return [ meshtasticChannel ];
+        return meshtasticChannel ? [ meshtasticChannel ] : null;
     }
     return channelsByMeshtasticHash[hash];
 };


### PR DESCRIPTION
## The crash

With a config whose `channels` contain only non-preset (private) channels — e.g. a single custom channel with `"meshtastic": true` — every received Meshtastic packet carrying an absent/zero channel hash (e.g. PKI direct messages seen on the LAN multicast) crashes the meshtastic receive path:

```
meshtastic recv: left-hand side expression is null
In decodePacket(), file meshtastic.uc, line 149, byte 72:
  called from function makeNativeMsg (meshtastic.uc:259:29)
  called from function recv (meshtastic.uc:331:45)
  called from function tick (router.uc:217:47)

 `                msg.decoded = crypto.decryptCTR(msg.from, msg.id, chan.symmetrickey, msg.encrypted);`
  Near here -------------------------------------------------------------^
```

## Root cause

`channel.uc` `getChannelsByMeshtasticHash(hash)` returns `[ meshtasticChannel ]` for a falsy hash — but `meshtasticChannel` is only assigned when a configured channel's namekey matches one of the stock `meshtasticChannelPresets` (`isMeshtasticPreset`). With only custom channels configured, the function returns `[ null ]`, which passes the caller's `if (hashchannels)` guard in `meshtastic.uc` and null-derefs at `chan.symmetrickey`.

## Fix

Return `null` when there is no preset channel, matching the unknown-channel-hash behavior. The sole caller (`decodePacket` in `meshtastic.uc`) already handles a null return and ignores the packet.

Observed several times a day on a long-running bridge (Raven ↔ meshtasticd on a Raspberry Pi over UDP multicast, private channel only) from ordinary direct-message traffic on the air; clean since patching. Reproduces on any platform — the code path is platform-independent.

Unrelated heads-up for installs on AREDN 4.26.x: the postinst's `restart-firewall` call trips an AREDN firmware bug (fw3 invoked on fw4 firmware) that wipes runtime firewall rules including WAN management access — filed as aredn/aredn#2762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
